### PR TITLE
Adding current system user to auth file token name

### DIFF
--- a/templates/abstract.tpl.php
+++ b/templates/abstract.tpl.php
@@ -500,7 +500,7 @@ abstract class <CLASSNAME_ABSTRACT>
 
         // build filename for cached auth token
         if($tokenCacheDir && array_key_exists('user', $params) && is_dir($tokenCacheDir))
-            $tokenCacheFile = $tokenCacheDir.'/.zabbixapi-token-'.md5($params['user']);
+            $tokenCacheFile = $tokenCacheDir.'/.zabbixapi-token-'.md5($params['user'].posix_getuid());
 
         // try to read cached auth token
         if(isset($tokenCacheFile) && is_file($tokenCacheFile))


### PR DESCRIPTION
Hello Dominique. Thank You for library. Very useful for me. I have a proposal to fix one problem.
In some cases php processes use same zabbix user to auth, but execute under different system users (shell, apache). So they will use the same auth file, but only the first will gain access. And the second process with different user will never use cached token.
Please aprove my change.
If I'm not mistaken it needs to rebuild new versions? What is sequence of actions to rebuild it for both 2.2 and 2.4 branches? Who should do it?
